### PR TITLE
found a bug in MoveFromCoord

### DIFF
--- a/board.go
+++ b/board.go
@@ -157,7 +157,7 @@ func MoveFromCoord(str string) (Move, error) {
 	if err != nil {
 		return NilMove, ErrUnknownMove
 	}
-	return Move{fromPos, toPos, promote}, nil
+	return Move{fromPos, toPos, promote, ""}, nil
 }
 
 func (b *Board) MakeAlgebraicMove(str string, color Color) error {
@@ -173,6 +173,7 @@ func (b *Board) MakeAlgebraicMove(str string, color Color) error {
 }
 
 func (b *Board) MoveFromAlgebraic(str string, color Color) (Move, error) {
+	san := strings.Trim(str, "!?")
 	str = strings.Trim(str, "+!?#")
 	//fmt.Println("move from alg:", str, "..", color)
 	if b.toMove != color {
@@ -195,7 +196,7 @@ func (b *Board) MoveFromAlgebraic(str string, color Color) (Move, error) {
 			if color == White {
 				testPos = PositionFromFileRank(f, r-1)
 				if b.GetPiece(testPos) == WhitePawn {
-					return Move{testPos, pos, promote}, nil
+					return Move{testPos, pos, promote, san}, nil
 				}
 				if pos == NoPosition {
 					return NilMove, fmt.Errorf("Position out of bounds")
@@ -203,7 +204,7 @@ func (b *Board) MoveFromAlgebraic(str string, color Color) (Move, error) {
 			} else {
 				testPos = PositionFromFileRank(f, r+1)
 				if b.GetPiece(testPos) == BlackPawn {
-					return Move{testPos, pos, promote}, nil
+					return Move{testPos, pos, promote, san}, nil
 				}
 				if pos == NoPosition {
 					return NilMove, fmt.Errorf("Position out of bounds")
@@ -231,12 +232,12 @@ func (b *Board) MoveFromAlgebraic(str string, color Color) (Move, error) {
 				if str[1] >= 'a' && str[1] <= 'h' {
 					fromPos, err = b.findAttackingKnightFromFile(pos, color, File(str[1]))
 					if err == nil {
-						return Move{fromPos, pos, NoPiece}, nil
+						return Move{fromPos, pos, NoPiece, san}, nil
 					}
 				} else if str[1] >= '1' && str[1] <= '8' {
 					fromPos, err = b.findAttackingKnightFromRank(pos, color, Rank(str[1]))
 					if err == nil {
-						return Move{fromPos, pos, NoPiece}, nil
+						return Move{fromPos, pos, NoPiece, san}, nil
 					}
 				}
 				return NilMove, ErrAmbiguousMove
@@ -244,7 +245,7 @@ func (b *Board) MoveFromAlgebraic(str string, color Color) (Move, error) {
 			if err != nil {
 				return NilMove, err
 			}
-			return Move{fromPos, pos, NoPiece}, nil
+			return Move{fromPos, pos, NoPiece, san}, nil
 		case 'B':
 			pos, err := ParsePosition(str[len(str)-2 : len(str)])
 			if err != nil {
@@ -255,7 +256,7 @@ func (b *Board) MoveFromAlgebraic(str string, color Color) (Move, error) {
 			if err != nil {
 				return NilMove, err
 			}
-			return Move{fromPos, pos, NoPiece}, nil
+			return Move{fromPos, pos, NoPiece, san}, nil
 		case 'R':
 			pos, err := ParsePosition(str[len(str)-2 : len(str)])
 			if err != nil {
@@ -266,19 +267,19 @@ func (b *Board) MoveFromAlgebraic(str string, color Color) (Move, error) {
 				if str[1] >= 'a' && str[1] <= 'h' {
 					fromPos, err = b.findAttackingRookFromFile(pos, color, File(str[1]))
 					if err == nil {
-						return Move{fromPos, pos, NoPiece}, nil
+						return Move{fromPos, pos, NoPiece, san}, nil
 					}
 				} else if str[1] >= '1' && str[1] <= '8' {
 					fromPos, err = b.findAttackingRookFromRank(pos, color, Rank(str[1]))
 					if err == nil {
-						return Move{fromPos, pos, NoPiece}, nil
+						return Move{fromPos, pos, NoPiece, san}, nil
 					}
 				}
 			}
 			if err != nil {
 				return NilMove, err
 			}
-			return Move{fromPos, pos, NoPiece}, nil
+			return Move{fromPos, pos, NoPiece, san}, nil
 		case 'Q':
 			pos, err := ParsePosition(str[len(str)-2 : len(str)])
 			if err != nil {
@@ -291,12 +292,12 @@ func (b *Board) MoveFromAlgebraic(str string, color Color) (Move, error) {
 				if str[1] >= 'a' && str[1] <= 'h' {
 					fromPos, err = b.findAttackingQueenFromFile(pos, color, File(str[1]))
 					if err == nil {
-						return Move{fromPos, pos, NoPiece}, nil
+						return Move{fromPos, pos, NoPiece, san}, nil
 					}
 				} else if str[1] >= '1' && str[1] <= '8' {
 					fromPos, err = b.findAttackingQueenFromRank(pos, color, Rank(str[1]))
 					if err == nil {
-						return Move{fromPos, pos, NoPiece}, nil
+						return Move{fromPos, pos, NoPiece, san}, nil
 					}
 				}
 			}
@@ -304,7 +305,7 @@ func (b *Board) MoveFromAlgebraic(str string, color Color) (Move, error) {
 			if err != nil {
 				return NilMove, err
 			}
-			return Move{fromPos, pos, NoPiece}, nil
+			return Move{fromPos, pos, NoPiece, san}, nil
 		case 'K':
 			pos, err := ParsePosition(str[len(str)-2 : len(str)])
 			if err != nil {
@@ -314,7 +315,7 @@ func (b *Board) MoveFromAlgebraic(str string, color Color) (Move, error) {
 			if err != nil {
 				return NilMove, err
 			}
-			return Move{fromPos, pos, NoPiece}, nil
+			return Move{fromPos, pos, NoPiece, san}, nil
 		}
 		// pawn taking move
 		if str[0] >= 'a' && str[0] <= 'h' && str[1] == 'x' {
@@ -326,13 +327,13 @@ func (b *Board) MoveFromAlgebraic(str string, color Color) (Move, error) {
 			if err == ErrAmbiguousMove {
 				fromPos, err = b.findAttackingPawnFromFile(pos, color, File(str[0]))
 				if err == nil {
-					return Move{fromPos, pos, promote}, nil
+					return Move{fromPos, pos, promote, san}, nil
 				}
 			}
 			if err != nil {
 				return NilMove, err
 			}
-			return Move{fromPos, pos, promote}, nil
+			return Move{fromPos, pos, promote, san}, nil
 		}
 	}
 	return NilMove, ErrUnknownMove
@@ -625,13 +626,13 @@ func (b Board) findAttackingPawn(pos Position, color Color, check bool) (Positio
 			b.GetPiece(PositionFromFileRank(pos.GetFile(), pos.GetRank()-1)) == BlackPawn {
 			testPos := PositionFromFileRank(pos.GetFile()+1, pos.GetRank()-1)
 			if b.GetPiece(testPos) == WhitePawn &&
-				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 				retPos = testPos
 				count++
 			}
 			testPos = PositionFromFileRank(pos.GetFile()-1, pos.GetRank()-1)
 			if b.GetPiece(testPos) == WhitePawn &&
-				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 				retPos = testPos
 				count++
 			}
@@ -640,13 +641,13 @@ func (b Board) findAttackingPawn(pos Position, color Color, check bool) (Positio
 		if b.GetPiece(pos).Color() == Black {
 			testPos := PositionFromFileRank(pos.GetFile()+1, pos.GetRank()-1)
 			if b.GetPiece(testPos) == WhitePawn &&
-				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 				retPos = testPos
 				count++
 			}
 			testPos = PositionFromFileRank(pos.GetFile()-1, pos.GetRank()-1)
 			if b.GetPiece(testPos) == WhitePawn &&
-				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 				retPos = testPos
 				count++
 			}
@@ -659,13 +660,13 @@ func (b Board) findAttackingPawn(pos Position, color Color, check bool) (Positio
 			b.GetPiece(PositionFromFileRank(pos.GetFile(), pos.GetRank()+1)) == WhitePawn {
 			testPos := PositionFromFileRank(pos.GetFile()+1, pos.GetRank()+1)
 			if b.GetPiece(testPos) == BlackPawn &&
-				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 				retPos = testPos
 				count++
 			}
 			testPos = PositionFromFileRank(pos.GetFile()-1, pos.GetRank()+1)
 			if b.GetPiece(testPos) == BlackPawn &&
-				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 				retPos = testPos
 				count++
 			}
@@ -673,13 +674,13 @@ func (b Board) findAttackingPawn(pos Position, color Color, check bool) (Positio
 		if b.GetPiece(pos).Color() == White {
 			testPos := PositionFromFileRank(pos.GetFile()+1, pos.GetRank()+1)
 			if b.GetPiece(testPos) == BlackPawn &&
-				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 				retPos = testPos
 				count++
 			}
 			testPos = PositionFromFileRank(pos.GetFile()-1, pos.GetRank()+1)
 			if b.GetPiece(testPos) == BlackPawn &&
-				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+				(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 				retPos = testPos
 				count++
 			}
@@ -749,7 +750,7 @@ func (b Board) findAttackingBishop(pos Position, color Color, check bool) (Posit
 		r--
 		testPos := PositionFromFileRank(f, r)
 		if b.checkBishopColor(testPos, color) &&
-			(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+			(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 		} else if testPos == NoPosition || b.containsPieceAt(testPos) {
@@ -764,7 +765,7 @@ func (b Board) findAttackingBishop(pos Position, color Color, check bool) (Posit
 		r++
 		testPos := PositionFromFileRank(f, r)
 		if b.checkBishopColor(testPos, color) &&
-			(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+			(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 		} else if testPos == NoPosition || b.containsPieceAt(testPos) {
@@ -779,7 +780,7 @@ func (b Board) findAttackingBishop(pos Position, color Color, check bool) (Posit
 		r++
 		testPos := PositionFromFileRank(f, r)
 		if b.checkBishopColor(testPos, color) &&
-			(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+			(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 		} else if testPos == NoPosition || b.containsPieceAt(testPos) {
@@ -794,7 +795,7 @@ func (b Board) findAttackingBishop(pos Position, color Color, check bool) (Posit
 		r--
 		testPos := PositionFromFileRank(f, r)
 		if b.checkBishopColor(testPos, color) &&
-			(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+			(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 		} else if testPos == NoPosition || b.containsPieceAt(testPos) {
@@ -926,7 +927,7 @@ func (b Board) getKingsideCastle(color Color) (Move, error) {
 		if b.positionAttackedBy(F1, Black) || b.positionAttackedBy(G1, Black) {
 			return NilMove, ErrMoveThroughCheck
 		}
-		return Move{E1, G1, NoPiece}, nil
+		return Move{E1, G1, NoPiece, "O-O"}, nil
 	} else {
 		if b.bCastle != Both && b.bCastle != Kingside {
 			return NilMove, ErrMoveInvalidCastle
@@ -937,7 +938,7 @@ func (b Board) getKingsideCastle(color Color) (Move, error) {
 		if b.positionAttackedBy(F8, White) || b.positionAttackedBy(G8, White) {
 			return NilMove, ErrMoveThroughCheck
 		}
-		return Move{E8, G8, NoPiece}, nil
+		return Move{E8, G8, NoPiece, "O-O"}, nil
 	}
 }
 
@@ -952,7 +953,7 @@ func (b Board) getQueensideCastle(color Color) (Move, error) {
 		if b.positionAttackedBy(C1, Black) || b.positionAttackedBy(D1, Black) {
 			return NilMove, ErrMoveThroughCheck
 		}
-		return Move{E1, C1, NoPiece}, nil
+		return Move{E1, C1, NoPiece, "O-O-O"}, nil
 	} else {
 		if b.bCastle != Both && b.bCastle != Queenside {
 			return NilMove, ErrMoveInvalidCastle
@@ -963,7 +964,7 @@ func (b Board) getQueensideCastle(color Color) (Move, error) {
 		if b.positionAttackedBy(C8, White) || b.positionAttackedBy(D8, White) {
 			return NilMove, ErrMoveThroughCheck
 		}
-		return Move{E8, C8, NoPiece}, nil
+		return Move{E8, C8, NoPiece, "O-O-O"}, nil
 	}
 }
 

--- a/board_knight.go
+++ b/board_knight.go
@@ -9,7 +9,7 @@ func (b Board) findAttackingKnight(pos Position, color Color, check bool) (Posit
 	testPos := PositionFromFileRank(f+1, r+2)
 	if testPos != NoPosition &&
 		b.checkKnightColor(testPos, color) &&
-		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 		count++
 		retPos = testPos
 	}
@@ -17,7 +17,7 @@ func (b Board) findAttackingKnight(pos Position, color Color, check bool) (Posit
 	testPos = PositionFromFileRank(f+1, r-2)
 	if testPos != NoPosition &&
 		b.checkKnightColor(testPos, color) &&
-		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 		count++
 		retPos = testPos
 	}
@@ -25,7 +25,7 @@ func (b Board) findAttackingKnight(pos Position, color Color, check bool) (Posit
 	testPos = PositionFromFileRank(f+2, r+1)
 	if testPos != NoPosition &&
 		b.checkKnightColor(testPos, color) &&
-		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 		count++
 		retPos = testPos
 	}
@@ -33,7 +33,7 @@ func (b Board) findAttackingKnight(pos Position, color Color, check bool) (Posit
 	testPos = PositionFromFileRank(f+2, r-1)
 	if testPos != NoPosition &&
 		b.checkKnightColor(testPos, color) &&
-		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 		count++
 		retPos = testPos
 	}
@@ -41,7 +41,7 @@ func (b Board) findAttackingKnight(pos Position, color Color, check bool) (Posit
 	testPos = PositionFromFileRank(f-2, r-1)
 	if testPos != NoPosition &&
 		b.checkKnightColor(testPos, color) &&
-		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 		count++
 		retPos = testPos
 	}
@@ -49,7 +49,7 @@ func (b Board) findAttackingKnight(pos Position, color Color, check bool) (Posit
 	testPos = PositionFromFileRank(f-2, r+1)
 	if testPos != NoPosition &&
 		b.checkKnightColor(testPos, color) &&
-		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 		count++
 		retPos = testPos
 	}
@@ -57,7 +57,7 @@ func (b Board) findAttackingKnight(pos Position, color Color, check bool) (Posit
 	testPos = PositionFromFileRank(f-1, r-2)
 	if testPos != NoPosition &&
 		b.checkKnightColor(testPos, color) &&
-		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 		count++
 		retPos = testPos
 	}
@@ -65,7 +65,7 @@ func (b Board) findAttackingKnight(pos Position, color Color, check bool) (Posit
 	testPos = PositionFromFileRank(f-1, r+2)
 	if testPos != NoPosition &&
 		b.checkKnightColor(testPos, color) &&
-		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		(!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 		count++
 		retPos = testPos
 	}

--- a/board_queen.go
+++ b/board_queen.go
@@ -10,7 +10,7 @@ func (b Board) findAttackingQueen(pos Position, color Color, check bool) (Positi
 	for {
 		f--
 		testPos := PositionFromFileRank(f, r)
-		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 			break
@@ -24,7 +24,7 @@ func (b Board) findAttackingQueen(pos Position, color Color, check bool) (Positi
 	for {
 		f++
 		testPos := PositionFromFileRank(f, r)
-		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 			break
@@ -38,7 +38,7 @@ func (b Board) findAttackingQueen(pos Position, color Color, check bool) (Positi
 	for {
 		r++
 		testPos := PositionFromFileRank(f, r)
-		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 			break
@@ -52,7 +52,7 @@ func (b Board) findAttackingQueen(pos Position, color Color, check bool) (Positi
 	for {
 		r--
 		testPos := PositionFromFileRank(f, r)
-		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 			break
@@ -68,7 +68,7 @@ func (b Board) findAttackingQueen(pos Position, color Color, check bool) (Positi
 		f--
 		r--
 		testPos := PositionFromFileRank(f, r)
-		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 			break
@@ -83,7 +83,7 @@ func (b Board) findAttackingQueen(pos Position, color Color, check bool) (Positi
 		f--
 		r++
 		testPos := PositionFromFileRank(f, r)
-		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 			break
@@ -98,7 +98,7 @@ func (b Board) findAttackingQueen(pos Position, color Color, check bool) (Positi
 		f++
 		r++
 		testPos := PositionFromFileRank(f, r)
-		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 			break
@@ -113,7 +113,7 @@ func (b Board) findAttackingQueen(pos Position, color Color, check bool) (Positi
 		f++
 		r--
 		testPos := PositionFromFileRank(f, r)
-		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		if b.checkQueenColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 			break

--- a/board_rook.go
+++ b/board_rook.go
@@ -9,7 +9,7 @@ func (b Board) findAttackingRook(pos Position, color Color, check bool) (Positio
 	for {
 		f--
 		testPos := PositionFromFileRank(f, r)
-		if b.checkRookColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		if b.checkRookColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 			break
@@ -23,7 +23,7 @@ func (b Board) findAttackingRook(pos Position, color Color, check bool) (Positio
 	for {
 		f++
 		testPos := PositionFromFileRank(f, r)
-		if b.checkRookColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		if b.checkRookColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 			break
@@ -37,7 +37,7 @@ func (b Board) findAttackingRook(pos Position, color Color, check bool) (Positio
 	for {
 		r++
 		testPos := PositionFromFileRank(f, r)
-		if b.checkRookColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		if b.checkRookColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 			break
@@ -51,7 +51,7 @@ func (b Board) findAttackingRook(pos Position, color Color, check bool) (Positio
 	for {
 		r--
 		testPos := PositionFromFileRank(f, r)
-		if b.checkRookColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece}, color)) {
+		if b.checkRookColor(testPos, color) && (!check || !b.moveIntoCheck(Move{testPos, pos, NoPiece, ""}, color)) {
 			retPos = testPos
 			count++
 			break

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/shric/pgn
+
+go 1.14
+
+require (
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
+)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shric/pgn
+module github.com/jvsteiner/pgn
 
 go 1.14
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/marshal.go
+++ b/marshal.go
@@ -1,0 +1,55 @@
+package pgn
+
+import (
+	"encoding/gob"
+	"os"
+)
+
+type exportedBoard struct {
+	WPawns        uint64
+	BPawns        uint64
+	WRooks        uint64
+	BRooks        uint64
+	WKnights      uint64
+	BKnights      uint64
+	WBishops      uint64
+	BBishops      uint64
+	WQueens       uint64
+	BQueens       uint64
+	WKings        uint64
+	BKings        uint64
+	LastMove      Move
+	WCastle       CastleStatus
+	BCastle       CastleStatus
+	ToMove        Color
+	Fullmove      int
+	HalfmoveClock int
+}
+
+func (b *Board) Save(path string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	var eb exportedBoard
+	eb.WPawns = b.wPawns
+	eb.BPawns = b.bPawns
+	eb.WRooks = b.wRooks
+	eb.BRooks = b.bRooks
+	eb.WKnights = b.wKnights
+	eb.BKnights = b.bKnights
+	eb.WBishops = b.wBishops
+	eb.BBishops = b.bBishops
+	eb.WQueens = b.wQueens
+	eb.BQueens = b.bQueens
+	eb.WKings = b.wKings
+	eb.BKings = b.bKings
+	eb.LastMove = b.lastMove
+	eb.WCastle = b.wCastle
+	eb.BCastle = b.bCastle
+	eb.ToMove = b.toMove
+	eb.Fullmove = b.fullmove
+	eb.HalfmoveClock = b.halfmoveClock
+	return gob.NewEncoder(file).Encode(eb)
+}

--- a/pgn.go
+++ b/pgn.go
@@ -53,6 +53,8 @@ func ParseTags(s *scanner.Scanner, g *Game) error {
 		switch run {
 		case '[', ']', '\n', '\r':
 			run = s.Next()
+		case '0':
+			return nil
 		case '1':
 			return nil
 		default:

--- a/pgn.go
+++ b/pgn.go
@@ -20,6 +20,7 @@ type Move struct {
 	From    Position
 	To      Position
 	Promote Piece
+	San     string
 }
 
 func (m Move) String() string {

--- a/pgn.go
+++ b/pgn.go
@@ -51,7 +51,7 @@ func ParseTags(s *scanner.Scanner, g *Game) error {
 	run := s.Peek()
 	for run != scanner.EOF {
 		switch run {
-		case '[', ']', '\n', '\r':
+		case '[', ']', '\n', '\r', ' ':
 			run = s.Next()
 		case '0':
 			return nil


### PR DESCRIPTION
board.go:158 chokes on moves that promote, because there are three characters being passed, but `parsePosition` checks that only 2 get passed.